### PR TITLE
Show/hide highlighted map layers on click & website links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8518,9 +8518,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-redux": "^7.1.0",
     "react-scripts": "^3.0.1",
     "react-window-size": "^1.2.0",
-    "redux": "^4.0.0"
+    "redux": "^4.0.0",
+    "url-parse": "^1.4.7"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,6 @@
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
   <meta name="theme-color" content="#dd4e36" />
-  <link rel="shortcut icon" type="image/x-icon" href="https://static1.squarespace.com/static/5c5b5ef4ab1a623eb4af6637/t/5c5b5f30ec212de29eb9b7d6/favicon.ico"/>
   <link rel="canonical" href="https://map.capitolhillblockparty.com"/>
   <meta property="og:site_name" content="Capitol Hill Block Party"/>
   <meta property="og:title" content="Capitol Hill Block Party"/>
@@ -14,6 +13,7 @@
   <meta property="og:image" content="http://static1.squarespace.com/static/5c5b5ef4ab1a623eb4af6637/t/5c5b5f299b747a2488a16694/1549492012291/CHBP+Logo+Black.png?format=1500w"/>
   <meta property="og:image:width" content="1500"/>
   <meta property="og:image:height" content="1500"/>
+  <meta property="og:description" content="Capitol Hill Block Party is an annual 3-day festival celebrating music, art and the neighborhood itself in the heart of Seattle…"/>
   <meta itemprop="name" content="Capitol Hill Block Party"/>
   <meta itemprop="url" content="https://map.capitolhillblockparty.com"/>
   <meta itemprop="thumbnailUrl" content="http://static1.squarespace.com/static/5c5b5ef4ab1a623eb4af6637/t/5c5b5f299b747a2488a16694/1549492012291/CHBP+Logo+Black.png?format=1500w"/>
@@ -22,8 +22,10 @@
   <meta name="twitter:title" content="Capitol Hill Block Party"/>
   <meta name="twitter:image" content="http://static1.squarespace.com/static/5c5b5ef4ab1a623eb4af6637/t/5c5b5f299b747a2488a16694/1549492012291/CHBP+Logo+Black.png?format=1500w"/>
   <meta name="twitter:url" content="https://map.capitolhillblockparty.com"/>
-  <meta name="twitter:card" content="summary"/>
-  <meta name="description" content="" />
+  <meta name="twitter:card" content="Capitol Hill Block Party is an annual 3-day festival celebrating music, art and the neighborhood itself in the heart of Seattle…"/>
+  <meta name="description" content="Capitol Hill Block Party is an annual 3-day festival celebrating music, art and the neighborhood itself in the heart of Seattle…" />
+  <meta name="application-name" content="Capitol Hill Block Party"/>
+
   <!--
     manifest.json provides metadata used when your web app is installed on a
     user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/components/BottomDrawer/BottomDrawer.js
+++ b/src/components/BottomDrawer/BottomDrawer.js
@@ -7,6 +7,17 @@ import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 import {connect} from "react-redux";
 import {toggleBottomDrawer} from '../../redux/actions';
 import './BottomDrawer.scss';
+import {
+  LAYER_BAR_RETAIL_SERVICE_LABEL,
+  LAYER_BAR_RETAIL_SERVICE_SELECTED,
+  LAYER_BEER_GARDEN_LOUNGE_OUTLINE,
+  LAYER_FREE_EVENTS_LABEL,
+  LAYER_FREE_EVENTS_SELECTED,
+  LAYER_NONPROFIT_LABEL,
+  LAYER_NONPROFIT_SELECTED
+} from "../../redux/constants";
+
+let parse = require('url-parse');
 
 
 const styles = theme => ({
@@ -44,7 +55,8 @@ class BottomSheet extends Component {
     const {classes, bottomDrawer} = this.props;
     const {options, data} = bottomDrawer;
     const {open, anchor} = options;
-    let header = this.getHeader(data)
+    let header = this.getHeader(data);
+    let website = this.getWebsite(data);
 
     return (
       <div>
@@ -54,11 +66,7 @@ class BottomSheet extends Component {
           open={open}
           onClose={() => {
             toggleBottomDrawer(false);
-            // Clear highlight filter
-            // map.setFilter('vendor pins highlight',
-            //   ["all",
-            //     ["==", "id", 0],
-            //   ]);
+            this.clearAllHighlightFilters();
           }}
           onOpen={() =>toggleBottomDrawer(true)}
           disableBackdropTransition={true}
@@ -66,13 +74,20 @@ class BottomSheet extends Component {
         >
           <div className="wrapperText">
             {header}
-            <Close onClick={() => toggleBottomDrawer(false)} className={classes.icon}>
+            <Close
+              className={classes.icon}
+              onClick={() => {
+                this.clearAllHighlightFilters();
+                toggleBottomDrawer(false);
+              }}
+            >
               close
             </Close>
 
             <div className="content-wrapper">
               <div className="title">{data.name}</div>
               <div className="category">{data.type}</div>
+              {website}
               <div className="custom-content-wrapper">
 
                 {/*Need to show the following*/}
@@ -88,11 +103,42 @@ class BottomSheet extends Component {
     );
   }
 
-  getBottomSheetTemplate = (item) => {
+  clearMapFilter = (filterName) => {
 
-    if (item.hasOwnProperty("id")) {
+    const {map} = this.props;
+    map.setFilter(filterName,
+      ["all",
+        ["==", "id", 0],
+      ]);
+  }
+
+  hideMapLayer = (layerName) => {
+
+    const {map} = this.props;
+    const visibility = map.getLayoutProperty(layerName, 'visibility');
+
+    if (visibility === 'visible') {
+      map.setLayoutProperty(layerName, 'visibility', 'none');
     }
 
+  }
+
+  clearAllHighlightFilters = () => {
+    this.clearMapFilter(LAYER_BAR_RETAIL_SERVICE_SELECTED);
+    this.clearMapFilter(LAYER_BAR_RETAIL_SERVICE_LABEL);
+    this.clearMapFilter(LAYER_BEER_GARDEN_LOUNGE_OUTLINE);
+    this.clearMapFilter(LAYER_NONPROFIT_LABEL);
+    this.clearMapFilter(LAYER_NONPROFIT_SELECTED);
+    this.clearMapFilter(LAYER_FREE_EVENTS_LABEL);
+    this.clearMapFilter(LAYER_FREE_EVENTS_SELECTED);
+
+    this.hideMapLayer(LAYER_BAR_RETAIL_SERVICE_SELECTED);
+    this.hideMapLayer(LAYER_BAR_RETAIL_SERVICE_LABEL)
+    this.hideMapLayer(LAYER_BEER_GARDEN_LOUNGE_OUTLINE)
+    this.hideMapLayer(LAYER_NONPROFIT_LABEL)
+    this.hideMapLayer(LAYER_NONPROFIT_SELECTED)
+    this.hideMapLayer(LAYER_FREE_EVENTS_LABEL)
+    this.hideMapLayer(LAYER_FREE_EVENTS_SELECTED)
   }
 
   getHeader(data) {
@@ -120,6 +166,19 @@ class BottomSheet extends Component {
           </div>
         </div>)
       // Show nothing
+    } else {
+      return null;
+    }
+  }
+
+  getWebsite(data) {
+
+    if (typeof data !== "undefined") {
+      let website = typeof data.website !== "undefined" && data.website.length > 0 ?
+        (<a className="category" target="_blank"
+            href={`https:/${parse(data.website).pathname}`}>https:/{parse(data.website).pathname}</a>) : null;
+      console.log(parse(data.website))
+      return website;
     } else {
       return null;
     }

--- a/src/components/BottomDrawer/BottomDrawer.js
+++ b/src/components/BottomDrawer/BottomDrawer.js
@@ -175,7 +175,7 @@ class BottomSheet extends Component {
 
     if (typeof data !== "undefined") {
       let website = typeof data.website !== "undefined" && data.website.length > 0 ?
-        (<a className="category" target="_blank"
+        (<a className="category" target="_blank" rel="noopener noreferrer"
             href={`https:/${parse(data.website).pathname}`}>https:/{parse(data.website).pathname}</a>) : null;
       console.log(parse(data.website))
       return website;

--- a/src/components/BottomDrawer/BottomDrawer.scss
+++ b/src/components/BottomDrawer/BottomDrawer.scss
@@ -55,6 +55,7 @@
     font-size: 14px;
     font-family: 'Open Sans', sans-serif;
     font-weight: 300;
+    margin: 20px 0 0 0;
 }
 
 .category {
@@ -62,7 +63,6 @@
     font-weight: 300;
     font-size: 14px;
     color: #333;
-    margin: 0 0 20px 0;
 }
 
 .drawerSubHead {

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -17,7 +17,17 @@ import {
   FIND_MY_LOCATION_ERROR,
   FIND_MY_LOCATION_OUT_OF_BOUNDS,
   FIND_MY_LOCATION_SELECT,
-  FIND_MY_LOCATION_SUCCESS
+  FIND_MY_LOCATION_SUCCESS,
+  LAYER_BAR_RETAIL_SERVICE,
+  LAYER_BAR_RETAIL_SERVICE_LABEL,
+  LAYER_BAR_RETAIL_SERVICE_SELECTED,
+  LAYER_BEER_GARDEN, LAYER_BEER_GARDEN_LOUNGE_LABEL,
+  LAYER_BEER_GARDEN_LOUNGE_OUTLINE,
+  LAYER_FREE_EVENTS,
+  LAYER_FREE_EVENTS_LABEL, LAYER_FREE_EVENTS_SELECTED,
+  LAYER_NONPROFIT,
+  LAYER_NONPROFIT_LABEL, LAYER_NONPROFIT_SELECTED,
+  LAYER_STAGE
 } from "../../redux/constants";
 
 mapboxgl.accessToken = config.map.accessToken;
@@ -95,28 +105,69 @@ class Map extends Component {
 
   // Display feature info in bottom panel
   displayFeatureInfo(e, features) {
-    const data = features[0].properties;
-    // const {map} = this.props;
+    const data = features[0];
+    const {map} = this.props;
+    const layer = data.layer.id;
+    console.log("SELECTED LAYER", layer);
 
-    setBottomDrawerData(data);
+    // Map containing list of highlight layers associated with each layer. For example, the "bars-retail-service" layer
+    // has two additional layers rendered on top: "bars-retail-service-selected" and "bars-retail-service-label"
+    const layerHighLightMap = {
+      [LAYER_STAGE]: [LAYER_BEER_GARDEN_LOUNGE_OUTLINE],
+      [LAYER_BAR_RETAIL_SERVICE]: [LAYER_BAR_RETAIL_SERVICE_SELECTED, LAYER_BAR_RETAIL_SERVICE_LABEL],
+      [LAYER_BEER_GARDEN]: [LAYER_BEER_GARDEN_LOUNGE_OUTLINE],
+      [LAYER_BEER_GARDEN_LOUNGE_LABEL]: [LAYER_BEER_GARDEN_LOUNGE_OUTLINE],
+      [LAYER_NONPROFIT]: [LAYER_NONPROFIT_LABEL, LAYER_NONPROFIT_SELECTED],
+      [LAYER_FREE_EVENTS]: [LAYER_FREE_EVENTS_LABEL, LAYER_FREE_EVENTS_SELECTED]
+    };
+    let highlightLayer =  typeof layerHighLightMap[layer] === "object" ? layerHighLightMap[layer] : null;
+    console.log("HIGHLIGHT LAYER", highlightLayer);
+    if (highlightLayer !== null) {
+      highlightLayer.forEach(layer => {
+        map.setLayoutProperty(layer, "visibility", "visible");
+      })
+    }
+
+    setBottomDrawerData(data.properties);
     toggleBottomDrawer(true);
     // Record feature selection on google analytics
-    selectMapItem(data.name);
+    selectMapItem(data.properties.name);
 
-    // map.setFilter("vendor pins highlight", [
-    //   "all",
-    //   ["!=", "type", ""],
-    //   ["!=", "type", ""],
-    //   ["!=", "type", ""],
-    //   ["!=", "type", ""],
-    //   ["!=", "name", ""],
-    //   ["!=", "name", ""],
-    //   ["!=", "name", ""],
-    //   ["==", "id", data.id],
-    //   ["!=", "show_icon", true]
-    // ]);
+    map.setFilter(LAYER_BEER_GARDEN_LOUNGE_OUTLINE, [
+      "all",
+      ["!=", "type", "Restaurant / Bar"],
+      ["==", "id", data.properties.id]
+    ]);
 
-    // map.setLayoutProperty("vendor pins highlight", "visibility", "visible");
+    map.setFilter(LAYER_BAR_RETAIL_SERVICE_LABEL, [
+      "all",
+      ["==", "id", data.properties.id]
+    ])
+
+    map.setFilter(LAYER_BAR_RETAIL_SERVICE_SELECTED, [
+      "all",
+      ["==", "id", data.properties.id]
+    ])
+
+    map.setFilter(LAYER_NONPROFIT_LABEL, [
+      "all",
+      ["==", "id", data.properties.id]
+    ])
+
+    map.setFilter(LAYER_NONPROFIT_SELECTED, [
+      "all",
+      ["==", "id", data.properties.id]
+    ])
+
+    map.setFilter(LAYER_FREE_EVENTS_LABEL, [
+      "all",
+      ["==", "id", data.properties.id]
+    ])
+
+    map.setFilter(LAYER_FREE_EVENTS_SELECTED, [
+      "all",
+      ["==", "id", data.properties.id]
+    ])
   }
 
   /**
@@ -193,11 +244,19 @@ class Map extends Component {
     // TODO grab this layer list from a configuration
     let features = map.queryRenderedFeatures(e.point, {
       layers: [
-        "free-events",
-        "sponsors-nonprofit",
-        "stages",
-        "bars-retail-service",
-        "beer-garden-lounge"
+        LAYER_FREE_EVENTS,
+        LAYER_FREE_EVENTS_LABEL,
+        LAYER_FREE_EVENTS_SELECTED,
+        LAYER_NONPROFIT,
+        LAYER_NONPROFIT_LABEL,
+        LAYER_NONPROFIT_SELECTED,
+        LAYER_STAGE,
+        LAYER_BAR_RETAIL_SERVICE,
+        LAYER_BAR_RETAIL_SERVICE_LABEL,
+        LAYER_BAR_RETAIL_SERVICE_SELECTED,
+        LAYER_BEER_GARDEN,
+        LAYER_BEER_GARDEN_LOUNGE_OUTLINE,
+        LAYER_BEER_GARDEN_LOUNGE_LABEL
       ]
     });
 

--- a/src/redux/constants.js
+++ b/src/redux/constants.js
@@ -18,7 +18,20 @@ const SET_MAP = 'SET_MAP';
 
 const SET_TAB_VALUE = 'SET_TAB_VALUE';
 
-// TODO put this in a better place
+const LAYER_FREE_EVENTS = "free-events";
+const LAYER_FREE_EVENTS_LABEL = "free-events-label";
+const LAYER_FREE_EVENTS_SELECTED = "free-events-selected";
+const LAYER_NONPROFIT = "sponsors-nonprofit";
+const LAYER_NONPROFIT_LABEL = "sponsors-nonprofit-label";
+const LAYER_NONPROFIT_SELECTED = "sponsors-nonprofit-selected";
+const LAYER_STAGE = "stage";
+const LAYER_BEER_GARDEN = "beer-garden-lounge";
+const LAYER_BEER_GARDEN_LOUNGE_OUTLINE = "beer-garden-lounge-outline";
+const LAYER_BEER_GARDEN_LOUNGE_LABEL = "beer-garden-lounge-label";
+const LAYER_BAR_RETAIL_SERVICE = "bars-retail-service";
+const LAYER_BAR_RETAIL_SERVICE_SELECTED = "bars-retail-service-selected";
+const LAYER_BAR_RETAIL_SERVICE_LABEL = "bars-retail-service-label";
+
 const drawerWidth = 280;
 
 export {
@@ -36,5 +49,18 @@ export {
   FIND_MY_LOCATION_OUT_OF_BOUNDS,
   SET_TAB_VALUE,
   SET_MAP,
-  drawerWidth
+  drawerWidth,
+  LAYER_BAR_RETAIL_SERVICE,
+  LAYER_BAR_RETAIL_SERVICE_LABEL,
+  LAYER_BAR_RETAIL_SERVICE_SELECTED,
+  LAYER_BEER_GARDEN,
+  LAYER_BEER_GARDEN_LOUNGE_LABEL,
+  LAYER_BEER_GARDEN_LOUNGE_OUTLINE,
+  LAYER_FREE_EVENTS,
+  LAYER_FREE_EVENTS_LABEL,
+  LAYER_FREE_EVENTS_SELECTED,
+  LAYER_NONPROFIT,
+  LAYER_NONPROFIT_LABEL,
+  LAYER_NONPROFIT_SELECTED,
+  LAYER_STAGE
 }


### PR DESCRIPTION
### Description:

A bunch of new additions to the map experience:
- show feature highlight layers on click. This includes showing names for all point features, as well as an outline layer for polygons
- parse url and create link in bottom panel

I also cleaned up all the layer names and moved them into the constants file

### UI images:

Parsed url
<img width="649" alt="Screen Shot 2019-07-16 at 1 07 04 AM" src="https://user-images.githubusercontent.com/1947857/61277217-959b5a80-a766-11e9-8133-07aa3b90489c.png">


Select beer garden and main stage
<img width="339" alt="Screen Shot 2019-07-16 at 1 07 42 AM" src="https://user-images.githubusercontent.com/1947857/61277163-7270ab00-a766-11e9-8ca4-d5d49d680bd5.png">

<img width="289" alt="Screen Shot 2019-07-16 at 1 07 19 AM" src="https://user-images.githubusercontent.com/1947857/61277176-7c92a980-a766-11e9-8580-36f76de1d9e1.png">

Selected Restaurant / Bar
<img width="299" alt="Screen Shot 2019-07-16 at 1 07 13 AM" src="https://user-images.githubusercontent.com/1947857/61277187-83b9b780-a766-11e9-90ef-adf35a7f57fd.png">

### Unit Test Approach:

Describe unit tests being added with that PR.

### Test Results:
- [ ] Did you run `npm test` and did the results pass?
- [ ] Did you add unit tests that cover your changes?

Describe other (non-unit) test results here.
