### PR TITLE
Default bearing based on viewport

### DIFF
--- a/src/components/LeftDrawer/LeftDrawer.js
+++ b/src/components/LeftDrawer/LeftDrawer.js
@@ -8,6 +8,7 @@ import List from '@material-ui/core/List';
 import Divider from '@material-ui/core/Divider';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
+import {OpenInNewSharp} from '@material-ui/icons';
 import {
   toggleLeftDrawer,
   selectLeftMenuItem,
@@ -174,6 +175,7 @@ class LeftDrawer extends Component {
             <ListItem classes={{root: classes.list}} className="list-item-wrapper" button>
               <ListItemText disableTypography={true} classes={{root: 'list-item-text'}}
                             primary="Capitol Hill Block Party Official Website"/>
+                              <OpenInNewSharp className="link-icon">open_in_new</OpenInNewSharp>
             </ListItem>
           </a>
         </List>

--- a/src/components/LeftDrawer/LeftDrawer.scss
+++ b/src/components/LeftDrawer/LeftDrawer.scss
@@ -108,3 +108,8 @@
     width: 15px;
     background-color: $purple;
 }
+
+.link-icon {
+    font-size: 14px !important;
+    color: rgba(0, 0, 0, 0.87);
+}

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -70,12 +70,13 @@ class Map extends Component {
 
   componentDidMount() {
 
+    const {width} = this.props;
     const map = new mapboxgl.Map({
       container: this.mapContainer,
       style: config.map.style,
       center: config.map.center,
-      zoom: config.map.zoom,
-      bearing: config.map.bearing
+      zoom: width === 'xs' || width === 'sm' ? config.map.zoom.mobile : config.map.zoom.desktop,
+      bearing: width === 'xs' || width === 'sm' ? config.map.bearing.mobile : config.map.bearing.desktop
     });
 
     map.addControl(this.geoLocate);

--- a/src/config.js
+++ b/src/config.js
@@ -36,8 +36,14 @@ const config = {
     "style": "mapbox://styles/spatialdev/cjxyccxk90prc1cpyq11zt62g",
     "center": [-122.319, 47.614],
     "bounds": [[-122.32140396058543, 47.612702531671545], [-122.3144109050901, 47.61535256842217]],
-    "zoom": 16.75,
-    "bearing": 270
+    "zoom": {
+      "mobile": 16.75,
+      "desktop": 17.65
+    },
+    "bearing": {
+      "mobile": 270,
+      "desktop": 0
+    }
   }
 };
 

--- a/src/data/chbp_centroids_2019.json
+++ b/src/data/chbp_centroids_2019.json
@@ -1,0 +1,288 @@
+{
+  "type": "FeatureCollection",
+  "name": "polygon_centroids_2019",
+  "crs": {
+    "type": "name",
+    "properties": {
+      "name": "urn:ogc:def:crs:OGC:1.3:CRS84"
+    }
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "fid": 1,
+        "description": "Opening its doors alongside Bimbos Cantina on Cinco de Mayo in 1998,  Cha Cha Lounge is a beachside tiki bar lifted from its tropical locale somewhere south of Acapulco and plopped down in the middle of Seattle.",
+        "icon": "",
+        "id": "5",
+        "left_panel": "",
+        "name": "Cha Cha",
+        "rotate": "",
+        "show_icon": "",
+        "show_label": "",
+        "type": "Stage",
+        "website": "chachalounge.com/seattle"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.318738980275,
+          47.613916654465
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fid": 2,
+        "description": "null",
+        "icon": "",
+        "id": "4",
+        "left_panel": "",
+        "name": "Barboza",
+        "rotate": "f",
+        "show_icon": "",
+        "show_label": "",
+        "type": "Stage",
+        "website": "null"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.31964801377502,
+          47.613787500380006
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fid": 3,
+        "description": "Brand new just last year, the highly popular Chophouse Row Courtyard DJs are back for CHBP 2019! We‚Äôve partnered with Chophouse Row again to bring you live DJ sets in their intimate indoor / outdoor courtyard. Free to the public via access from Chophouse‚Äôs entrance on 12th Avenue, and also available to CHBP ticket holders within the festival gates. Taking place each day of the festival, we‚Äôll have live sets from a variety of local DJs.",
+        "icon": "",
+        "id": "8",
+        "left_panel": "",
+        "name": "Chophouse Row",
+        "rotate": "",
+        "show_icon": "",
+        "show_label": "",
+        "type": "Free Event",
+        "website": "null"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.3176805586483,
+          47.61369422734922
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fid": 4,
+        "description": "null",
+        "icon": "",
+        "id": "152",
+        "left_panel": "",
+        "name": "Beer Garden - Pike",
+        "rotate": "",
+        "show_icon": "",
+        "show_label": "",
+        "type": "",
+        "website": "null"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.31921969201916,
+          47.61406453591216
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fid": 5,
+        "description": "null",
+        "icon": "",
+        "id": "1",
+        "left_panel": "",
+        "name": "Main Stage",
+        "rotate": "",
+        "show_icon": "",
+        "show_label": "",
+        "type": "Stage",
+        "website": "null"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.32042674838,
+          47.614092821645
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fid": 6,
+        "description": "null",
+        "icon": "",
+        "id": "3",
+        "left_panel": "",
+        "name": "Neumos",
+        "rotate": "",
+        "show_icon": "",
+        "show_label": "",
+        "type": "Stage",
+        "website": "null"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.319727938865,
+          47.613932414135
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fid": 7,
+        "description": "null",
+        "icon": "",
+        "id": "153",
+        "left_panel": "",
+        "name": "Beer Garden - Vera",
+        "rotate": "",
+        "show_icon": "",
+        "show_label": "",
+        "type": "",
+        "website": "null"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.31800684114314,
+          47.61412687474832
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fid": 8,
+        "description": "null",
+        "icon": "",
+        "id": "119",
+        "left_panel": "",
+        "name": "The Lounge by AT&T ",
+        "rotate": "",
+        "show_icon": "",
+        "show_label": "",
+        "type": "Sponsor ",
+        "website": "null"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.319391925405,
+          47.614355259170004
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fid": 9,
+        "description": "null",
+        "icon": "",
+        "id": "155",
+        "left_panel": "",
+        "name": "Food Court",
+        "rotate": "",
+        "show_icon": "",
+        "show_label": "",
+        "type": "null",
+        "website": "null"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.3189334160064,
+          47.61433945360242
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fid": 10,
+        "description": "Wildrose is one of the oldest lesbian bars on the West Coast, offering DJs, karaoke & seasonal outdoor seating.",
+        "icon": "",
+        "id": "62",
+        "left_panel": "",
+        "name": "Wildrose",
+        "rotate": "",
+        "show_icon": "",
+        "show_label": "",
+        "type": "Restaurant / Bar",
+        "website": "wildrosebar.com"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.31832163095,
+          47.61391808106
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fid": 11,
+        "description": "Cafe Pettirosso has had many forms since Robin Wright started it as a coffee cart. Yuki and Miki Sodos, sisters and co-owners of Bang Bang Cafe reopened Cafe Pettirosso in 2011. No stranger to the community surrounding the cafe, Yuki had managed Cafe Pettirosso off and on for the previous 10 years and was thrilled when Robin suggested she take over Pettirosso with her sister. While the business has changed in certain ways, the love behind every day at Cafe Pettirosso has only grown.",
+        "icon": "",
+        "id": "31",
+        "left_panel": "",
+        "name": "Cafe Pettirosso",
+        "rotate": "",
+        "show_icon": "",
+        "show_label": "",
+        "type": "Restaurant / Bar",
+        "website": "pettirossoseattle.com"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.31797290891001,
+          47.61387617833
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "fid": 12,
+        "description": "null",
+        "icon": "",
+        "id": "2",
+        "left_panel": "",
+        "name": "Clif Bar Presents: Vera Stage",
+        "rotate": "",
+        "show_icon": "",
+        "show_label": "",
+        "type": "Stage",
+        "website": "null"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.31818596152,
+          47.613870077345
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description:

This updates the default bearing to be N/S on desktop, and E/W on mobile.
I also added a "open in new tab" icon in the bottom left panel.

### UI images:

North / South
<img width="958" alt="Screen Shot 2019-07-17 at 8 36 16 PM" src="https://user-images.githubusercontent.com/1947857/61429312-98b75780-a8da-11e9-8d61-efb779396be1.png">

East / West
<img width="1084" alt="Screen Shot 2019-07-17 at 8 37 19 PM" src="https://user-images.githubusercontent.com/1947857/61429321-a5d44680-a8da-11e9-8e4c-215bb72341a0.png">

<img width="320" alt="Screen Shot 2019-07-17 at 9 36 04 PM" src="https://user-images.githubusercontent.com/1947857/61429378-ea5fe200-a8da-11e9-8fc9-6049fc24a111.png">


### Unit Test Approach:

Describe unit tests being added with that PR.

### Test Results:
- [ ] Did you run `npm test` and did the results pass?
- [ ] Did you add unit tests that cover your changes?

Describe other (non-unit) test results here.
