### PR TITLE
Fix reset app button bug

### DIFF
--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -74,7 +74,7 @@ class Main extends Component {
   }
 
   resetView () {
-    const { map } = this.props;
+    const { map, width } = this.props;
 
     toggleLeftDrawer(false);
     toggleRightDrawer(false);
@@ -82,7 +82,7 @@ class Main extends Component {
 
     map.flyTo({
       center: config.map.center,
-      zoom: config.map.zoom
+      zoom:  width === 'xs' || width === 'sm' ? config.map.zoom.mobile : config.map.zoom.desktop
     })
   }
 


### PR DESCRIPTION
### Description:

The reset app button was using the old config keys to find the correct zoom level. This updates the reset app function to zoom based on viewport size

### UI images:

Please add images for any changes to the UI.

### Unit Test Approach:

Describe unit tests being added with that PR.

### Test Results:
- [ ] Did you run `npm test` and did the results pass?
- [ ] Did you add unit tests that cover your changes?

Describe other (non-unit) test results here.
